### PR TITLE
Added requirements.txt and removed/commented out `pip install` and `git checkout` cells in the notebook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python>=3.12,<3.13
 pyam-iamc>=2.2
 pandas>=2.2
 unfccc-di-api

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+python>=3.12,<3.13
+pyam-iamc>=2.2
+pandas>=2.2
+unfccc-di-api
+eofs
+corner
+fsspec
+ipykernel


### PR DESCRIPTION
I created a requirements.txt with required dependencies, and removed the corresponding `pip install` statements from the notebook. I added back a commented-out, cleaner cell with pip install commands to use when running on Colab (didn't find a practical way of using the requirements.txt file there), and a Markdown cell with instructions for what to do when running locally.

The development version of pyam that was added through `git checkout` commands doesn't appear to be needed. The functionality for reading AR6 scenarios appears to be in the newer version of pyam. If it was needed for other reasons, then let me know, but the notebook runs fine with just the latest public version of pyam.

In the last commit I additionally ran the whole notebook. If you don't want these changes, I can revert that commit to leave only the requirements file and the removal of the pip install and git checkout commands from the notebook.

Note that the notebook I used was the latest version from the GitHub repo. It looks there might be a more recent version on Colab that hasn't been commited to GitHub?